### PR TITLE
updateed package.json to add 'mkdir _gen' to the swagger-gen script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run clean && npm run lint && npm run swagger-gen && npm run routes-gen",
     "lint": "tslint ./src/**/*.ts",
     "clean": "rimraf _gen",
-    "swagger-gen": "tsoa swagger",
+    "swagger-gen": "bash -c 'mkdir _gen' && tsoa swagger",
     "fix-swagger": "bash -c './scripts.sh fix-swagger'",
     "routes-gen": "bash -c 'mkdir -p _gen/routes' && tsoa routes",
     "tsoa": "tsoa"


### PR DESCRIPTION
at the moment `npm run start` or `npm run debug` will fail as the `_gen` sub-directory does not exist and consequently the `swagger-gen` script fails.